### PR TITLE
fix Avatar presence indicator

### DIFF
--- a/web/src/components/avatar/avatar/index.tsx
+++ b/web/src/components/avatar/avatar/index.tsx
@@ -99,7 +99,7 @@ export const Avatar: React.FC<AvatarProps> = props => {
       ) : (
         <div className={circle} />
       )}
-      {!isInactive && status && size !== 'x-small' && (
+      {!isInactive && status === 'online' && size !== 'x-small' && (
         <div className={classes.status} />
       )}
     </Wrapper>


### PR DESCRIPTION
only render the avatar status div if the status is one of the allowed `StatusType`. I hardcoded it